### PR TITLE
respect specifed text length in FTS3 tokenizer

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -5,28 +5,47 @@
 #   pre: false
 #   features: []
 #   all-features: false
+#   with-sources: false
 
 -e file:.
-black==23.9.1
-cffi==1.16.0 ; platform_python_implementation != "PyPy"
+black==24.2.0
+cffi==1.16.0
+    # via sqlitefts
 click==8.1.7
-faker==19.6.2
-flake8==6.1.0
+    # via black
+faker==23.2.1
+flake8==7.0.0
 iniconfig==2.0.0
-isort==5.12.0
+    # via pytest
+isort==5.13.2
 mccabe==0.7.0
-mypy==1.5.1
+    # via flake8
+mypy==1.8.0
 mypy-extensions==1.0.0
+    # via black
+    # via mypy
 packaging==23.2
-pathspec==0.11.2
-platformdirs==3.11.0
-pluggy==1.3.0
-pycodestyle==2.11.0
+    # via black
+    # via pytest
+pathspec==0.12.1
+    # via black
+platformdirs==4.2.0
+    # via black
+pluggy==1.4.0
+    # via pytest
+pycodestyle==2.11.1
+    # via flake8
 pycparser==2.21
-pyflakes==3.1.0
-pytest==7.4.2
+    # via cffi
+pyflakes==3.2.0
+    # via flake8
+pytest==8.0.1
 python-dateutil==2.8.2
+    # via faker
 six==1.16.0
-types-cffi==1.16.0.0
-types-setuptools==68.2.0.0
-typing-extensions==4.8.0
+    # via python-dateutil
+types-cffi==1.16.0.20240106
+types-setuptools==69.1.0.20240217
+    # via types-cffi
+typing-extensions==4.9.0
+    # via mypy

--- a/requirements.lock
+++ b/requirements.lock
@@ -5,7 +5,10 @@
 #   pre: false
 #   features: []
 #   all-features: false
+#   with-sources: false
 
 -e file:.
-cffi==1.16.0 ; platform_python_implementation != "PyPy"
+cffi==1.16.0
+    # via sqlitefts
 pycparser==2.21
+    # via cffi

--- a/sqlitefts/fts3.py
+++ b/sqlitefts/fts3.py
@@ -89,7 +89,7 @@ def make_tokenizer_module(tokenizer):
     def xopen(pTokenizer, pInput, nInput, ppCursor):
         cur = ffi.new("sqlite3_tokenizer_cursor *")
         tokenizer = ffi.from_handle(pTokenizer.t)
-        i = ffi.string(pInput).decode("utf-8")
+        i = ffi.string(pInput, nInput).decode("utf-8")
         tokens = [(n.encode("utf-8"), b, e) for n, b, e in tokenizer.tokenize(i) if n]
         tknh = ffi.new_handle(iter(tokens))
         cur.pTokenizer = pTokenizer

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -331,6 +331,14 @@ furnished to do so, subject to the following conditions:""",
         c.executemany("INSERT INTO docs(title, body) VALUES(?, ?)", docs)
         c.execute("CREATE VIRTUAL TABLE docs_term USING FTS4AUX(docs)")
         orig_terms = c.execute("SELECT * FROM docs_term").fetchall()
+        r = c.execute(
+            """SELECT * FROM docs WHERE docs MATCH '"binding" OR "あいうえお"'"""
+        ).fetchall()
+        assert len(r) == 2
+        r = c.execute(
+            """SELECT * FROM docs WHERE docs MATCH '"provides binding" OR あいうえお'"""
+        ).fetchall()
+        assert len(r) == 2
         c.execute("DROP TABLE docs_term")
         c.execute("DROP TABLE docs")
         fts.register_tokenizer(c, name, tokenizer_module)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -283,10 +283,25 @@ def test_tokenizer_output(c, tokenizer_module):
                 (t, expect[-1][2] + 1, expect[-1][2] + 1 + len(t.encode("utf-8")), i)
             )
         expect = expect[1:]
+        a = c.execute(
+            "SELECT token, start, end, position FROM tok1 WHERE input=?", [s]
+        ).fetchall()
         for a, e in zip(
             c.execute(
-                "SELECT token, start, end, position " "FROM tok1 WHERE input=?", [s]
+                "SELECT token, start, end, position FROM tok1 WHERE input=?", [s]
             ),
             expect,
         ):
             assert e == a
+
+        c.execute("CREATE VIRTUAL TABLE tok2 USING fts3tokenize()")
+        s = '"binding" OR "あいうえお"'
+        for a, e in zip(
+            c.execute(
+                "SELECT token, start, end, position FROM tok1 WHERE input=?", [s]
+            ),
+            c.execute(
+                "SELECT token, start, end, position FROM tok2 WHERE input=?", [s]
+            ),
+        ):
+            assert a == e

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,7 +19,7 @@ class SimpleTokenizer(fts.Tokenizer):
     def tokenize(self, text):
         for m in self._p.finditer(text):
             s, e = m.span()
-            t = text[s:e]
+            t = text[s:e].lower()
             l = len(t.encode("utf-8"))
             p = len(text[:s].encode("utf-8"))
             yield t, p, p + l
@@ -256,12 +256,12 @@ furnished to do so, subject to the following conditions:""",
 
 
 def test_tokenizer_output(c, tokenizer_module):
-    name = "simple"
+    name = "s"
     with sqlite3.connect(":memory:") as c:
         fts.register_tokenizer(c, name, tokenizer_module)
         c.execute("CREATE VIRTUAL TABLE tok1 USING fts3tokenize({})".format(name))
-        expect = [
-            ("This", 0, 4, 0),
+        expect: list[tuple[str | None, int, int, int]] = [
+            ("this", 0, 4, 0),
             ("is", 5, 7, 1),
             ("a", 8, 9, 2),
             ("test", 10, 14, 3),


### PR DESCRIPTION
it parsed beyond it was asked then it returned something not asked.

e.g.
```
"binding" OR "あいうえお"
```

SQLite3 opened the tokenizer twice. one for `binding` and the other for `あいうえお` by shifting the start pointer and limiting input length.
```
"binding" OR "あいうえお"
 * from here, length 7 bytes
```

```
"binding" OR "あいうえお"
              * from here and length 15bytes (3bytes char * 5)
```

but it parsed the input text entierl, thus generated too many token including `OR`.

fixed GH-36