### PR TITLE
allow fts5 iVersion greater than 2

### DIFF
--- a/tests/test_fts5.py
+++ b/tests/test_fts5.py
@@ -39,7 +39,7 @@ def tm():
 
 def test_fts5_api_from_db(c):
     fts5api = fts5.fts5_api_from_db(c)
-    assert fts5api.iVersion == 2
+    assert fts5api.iVersion >= 2  # 2, 3, 4, ...
     assert fts5api.xCreateTokenizer
     c.close()
 


### PR DESCRIPTION
allow iVersion >= 2

it is 3 now. see https://www.sqlite.org/fts5.html#extending_fts5
